### PR TITLE
添加nacos账号和密码的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,20 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+config.toml

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 | ------------------ | ---------------------------------------------- | ------------------------------------------------------- |
 | nginx_cmd          | nginx命令的全路径                              | "/usr/sbin/nginx"                                       |
 | nacos_addr         | nacos的地址                                    | "172.16.0.100:8848,172.16.0.101:8848,172.16.0.102:8848" |
+| nacos_username     | nacos账号                                      | nacos没有开启鉴权则注解该字段                           |
+| nacos_password     | nacos密码                                      | nacos没有开启鉴权则注解该字段                           |
 | reload_interval    | nginx reload命令执行间隔时间（ms  默认值1000） | 1000                                                    |
 | nacos_service_name | nacos服务名                                    | "com.nacos.service.impl.NacosService"                   |
 | nginx_config       | 需要修改nginx配置的路径                        | "/etc/nginx/nginx.conf"                                 |

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,17 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-client</artifactId>
-            <version>1.1.4</version>
+            <version>1.4.2</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/main/java/org/yeauty/service/MonitorService.java
+++ b/src/main/java/org/yeauty/service/MonitorService.java
@@ -14,6 +14,8 @@ public interface MonitorService {
 
     String NGINX_CMD = "nginx_cmd";
     String NACOS_ADDR = "nacos_addr";
+    String NACOS_USERNAME = "nacos_username";
+    String NACOS_PASSWORD = "nacos_password";
 
     String NGINX_CONFIG = "nginx_config";
     String NGINX_UPSTREAM = "nginx_upstream";

--- a/src/main/resources/config.toml.example
+++ b/src/main/resources/config.toml.example
@@ -1,0 +1,15 @@
+nginx_cmd = "/usr/sbin/nginx"
+nacos_addr = "172.16.0.100:8848,172.16.0.101:8848,172.16.0.102:8848"
+#nacos_username = "账号，没有则不填"
+#nacos_password = "密码，没有则不填"
+reload_interval = 1000
+
+[discover_config1]
+nginx_config = "/etc/nginx/nginx.conf"
+nginx_upstream = "upsteam1"
+nacos_service_name = "service1"
+
+[discover_config2]
+nginx_config = "/etc/nginx/nginx.conf"
+nginx_upstream = "upsteam2"
+nacos_service_name = "service2"


### PR DESCRIPTION
解决 #4 功能
在 toml 配置上新增 `nacos_username` 以及 `nacos_password` 两个参数（没有则不填）
另外升级了`nacos-client` 版本：1.1.4 -> 1.4.2